### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <version.jcip-annotations>1.0</version.jcip-annotations>
         <version.jsoup>1.9.2</version.jsoup>
         <version.junit>4.13.1</version.junit>
-        <version.log4j>2.17.0</version.log4j>
+        <version.log4j>2.17.1</version.log4j>
         <version.netty>4.1.42.Final</version.netty>
         <version.netty-tcnative>2.0.1.Final</version.netty-tcnative>
         <version.powermock>1.6.4</version.powermock>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832