### PR TITLE
Added SplitLookupOperation to Qonduit

### DIFF
--- a/operations/src/main/java/qonduit/operations/scanner/ScanOperation.java
+++ b/operations/src/main/java/qonduit/operations/scanner/ScanOperation.java
@@ -3,7 +3,6 @@ package qonduit.operations.scanner;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
@@ -11,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.netty.channel.ChannelHandlerContext;
+import qonduit.Server;
 import qonduit.api.request.WebSocketRequest;
 import qonduit.operation.BatchingOperation;
 
@@ -21,8 +21,8 @@ public class ScanOperation extends BatchingOperation<KVPair> {
     private ScanRequest request = null;
 
     @Override
-    public void init(ChannelHandlerContext context, AccumuloClient client, Authorizations auths, WebSocketRequest r) {
-        super.init(context, client, auths, r);
+    public void init(ChannelHandlerContext context, Server server, Authorizations auths, WebSocketRequest r) {
+        super.init(context, server, auths, r);
         if (r instanceof ScanRequest) {
             this.request = (ScanRequest) r;
             this.setBatchSize(this.request.getResultBatchSize());

--- a/operations/src/main/java/qonduit/operations/splits/SplitLookupOperation.java
+++ b/operations/src/main/java/qonduit/operations/splits/SplitLookupOperation.java
@@ -1,0 +1,125 @@
+package qonduit.operations.splits;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.rfile.RFile;
+import org.apache.accumulo.core.clientImpl.Namespace;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import qonduit.Server;
+import qonduit.api.request.WebSocketRequest;
+import qonduit.operation.Operation;
+import qonduit.store.SplitStore;
+import qonduit.util.JsonUtil;
+
+public class SplitLookupOperation implements Operation {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SplitLookupOperation.class);
+
+    private SplitLookupRequest request = null;
+    private ChannelHandlerContext ctx = null;
+    private Server server = null;
+
+    @Override
+    public void run() {
+
+        final SplitLookupResponse response = new SplitLookupResponse();
+        response.setRequestId(this.request.getRequestId());
+        response.setEndOfResults(true);
+
+        if (server.getSplitStore() == null) {
+            response.setErrorMessage("Split server is disabled.");
+        } else {
+
+            final String tableName = request.getTableName();
+            final String tableId = server.getDataStore().getConnector().tableOperations().tableIdMap().get(tableName);
+
+            if (tableName.startsWith(Namespace.ACCUMULO.name() + ".")) {
+                response.setErrorMessage("SplitStore does not keep splits for table: " + tableName);
+            } else if (tableId == null) {
+                response.setErrorMessage("Table does not exist: " + tableName);
+            } else {
+                final String lookup = request.getRow();
+
+                AtomicReference<Path> splitsFile = server.getSplitStore().getSplitsFileForTable(tableName);
+
+                if (splitsFile == null) {
+                    response.setErrorMessage("Splits file not created yet for table: " + tableName);
+                } else if (splitsFile == SplitStore.ERROR_REF) {
+                    response.setErrorMessage("Error creating splits file for table: " + tableName);
+                } else if (splitsFile == SplitStore.TABLE_DELETED_REF) {
+                    response.setErrorMessage("Table " + tableName + " deleted.");
+                } else {
+                    // do lookup
+                    Text lookupRow = MetadataSchema.TabletsSection.encodeRow(TableId.of(tableId), new Text(lookup));
+
+                    Scanner scanner = RFile.newScanner().from(splitsFile.get().toFile().getAbsolutePath())
+                            .withoutSystemIterators().withDataCache(1024).withIndexCache(1024).build();
+
+                    scanner.setRange(new Range(lookupRow, null));
+                    var iter = scanner.iterator();
+                    if (iter.hasNext()) {
+                        Map.Entry<Key, Value> entry = iter.next();
+                        Text endRow = MetadataSchema.TabletsSection.decodeRow(entry.getKey().getRow()).getSecond();
+                        Text prevRow = TabletColumnFamily.decodePrevEndRow(entry.getValue());
+                        response.setBeginRow(prevRow == null ? "null" : prevRow.toString());
+                        response.setEndRow(endRow == null ? "null" : endRow.toString());
+                    }
+                }
+            }
+        }
+
+        try {
+            ByteBuf buf = Unpooled.wrappedBuffer(JsonUtil.getObjectMapper().writeValueAsBytes(response));
+            this.ctx.writeAndFlush(new BinaryWebSocketFrame(buf));
+        } catch (JsonProcessingException e) {
+            LOG.error("Error serializing response to send back to client", e);
+        }
+    }
+
+    @Override
+    public void init(ChannelHandlerContext context, Server server, Authorizations auths, WebSocketRequest r) {
+        if (r instanceof SplitLookupRequest) {
+            this.request = (SplitLookupRequest) r;
+            this.server = server;
+        } else {
+            throw new UnsupportedOperationException();
+        }
+        this.ctx = context;
+    }
+
+    @Override
+    public WebSocketRequest getRequestType() {
+        return new SplitLookupRequest();
+    }
+
+    @Override
+    public Class<?> getResponseClass() {
+        return SplitLookupResponse.class;
+    }
+
+    @Override
+    public void close() {
+        // TODO Auto-generated method stub
+
+    }
+
+}

--- a/operations/src/main/java/qonduit/operations/splits/SplitLookupRequest.java
+++ b/operations/src/main/java/qonduit/operations/splits/SplitLookupRequest.java
@@ -1,0 +1,37 @@
+package qonduit.operations.splits;
+
+import qonduit.operation.OperationRequest;
+
+public class SplitLookupRequest extends OperationRequest {
+
+    public static final String operation = "split-lookup";
+
+    private String tableName;
+    private String row;
+
+    public SplitLookupRequest() {
+        super();
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public String getRow() {
+        return row;
+    }
+
+    public void setRow(String row) {
+        this.row = row;
+    }
+
+    @Override
+    public String getOperation() {
+        return operation;
+    }
+
+}

--- a/operations/src/main/java/qonduit/operations/splits/SplitLookupRequest.java
+++ b/operations/src/main/java/qonduit/operations/splits/SplitLookupRequest.java
@@ -1,5 +1,7 @@
 package qonduit.operations.splits;
 
+import com.google.common.base.Preconditions;
+
 import qonduit.operation.OperationRequest;
 
 public class SplitLookupRequest extends OperationRequest {
@@ -32,6 +34,12 @@ public class SplitLookupRequest extends OperationRequest {
     @Override
     public String getOperation() {
         return operation;
+    }
+
+    @Override
+    public void validate() {
+        Preconditions.checkArgument(tableName != null, "tableName is null");
+        Preconditions.checkArgument(row != null, "row is null");
     }
 
 }

--- a/operations/src/main/java/qonduit/operations/splits/SplitLookupResponse.java
+++ b/operations/src/main/java/qonduit/operations/splits/SplitLookupResponse.java
@@ -1,0 +1,30 @@
+package qonduit.operations.splits;
+
+import qonduit.operation.OperationResponse;
+
+public class SplitLookupResponse extends OperationResponse {
+
+    private String beginRow;
+    private String endRow;
+
+    public SplitLookupResponse() {
+        super();
+    }
+
+    public String getBeginRow() {
+        return beginRow;
+    }
+
+    public void setBeginRow(String beginRow) {
+        this.beginRow = beginRow;
+    }
+
+    public String getEndRow() {
+        return endRow;
+    }
+
+    public void setEndRow(String endRow) {
+        this.endRow = endRow;
+    }
+
+}

--- a/operations/src/main/java/qonduit/operations/version/VersionOperation.java
+++ b/operations/src/main/java/qonduit/operations/version/VersionOperation.java
@@ -1,6 +1,5 @@
 package qonduit.operations.version;
 
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import qonduit.Server;
 import qonduit.api.request.WebSocketRequest;
 import qonduit.operation.Operation;
 import qonduit.serialize.JsonSerializer;
@@ -24,7 +24,7 @@ public class VersionOperation implements Operation {
     private ChannelHandlerContext ctx = null;
 
     @Override
-    public void init(ChannelHandlerContext context, AccumuloClient client, Authorizations auths, WebSocketRequest r) {
+    public void init(ChannelHandlerContext context, Server server, Authorizations auths, WebSocketRequest r) {
         if (r instanceof VersionRequest) {
             this.request = (VersionRequest) r;
         } else {

--- a/operations/src/main/resources/META-INF/services/qonduit.operation.Operation
+++ b/operations/src/main/resources/META-INF/services/qonduit.operation.Operation
@@ -1,2 +1,3 @@
 qonduit.operations.version.VersionOperation
 qonduit.operations.scanner.ScanOperation
+qonduit.operations.splits.SplitLookupOperation

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
                 </property>
             </activation>
             <properties>
-                <maven.compiler.release>8</maven.compiler.release>
+                <maven.compiler.release>11</maven.compiler.release>
                 <!-- provide a default of no classifier when loading in Eclipse -->
                 <os.detected.classifier></os.detected.classifier>
             </properties>
@@ -492,7 +492,7 @@
                 <jdk>[9,)</jdk>
             </activation>
             <properties>
-                <maven.compiler.release>8</maven.compiler.release>
+                <maven.compiler.release>11</maven.compiler.release>
             </properties>
         </profile>
     </profiles>

--- a/server/src/main/java/qonduit/Configuration.java
+++ b/server/src/main/java/qonduit/Configuration.java
@@ -1,21 +1,21 @@
 package qonduit;
 
+import java.io.File;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.stereotype.Component;
 
-import qonduit.validator.NotEmptyIfFieldSet;
-
 import com.google.common.collect.Lists;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import qonduit.validator.NotEmptyIfFieldSet;
 
 @Component
 @ConfigurationProperties(prefix = "qonduit")
@@ -80,6 +80,9 @@ public class Configuration {
         @Valid
         @NestedConfigurationProperty
         private Scan scan = new Scan();
+        @Valid
+        @NestedConfigurationProperty
+        private SplitServer splitServer = new SplitServer();
 
         public String getInstanceName() {
             return instanceName;
@@ -100,6 +103,10 @@ public class Configuration {
 
         public Scan getScan() {
             return scan;
+        }
+
+        public SplitServer getSplitServer() {
+            return splitServer;
         }
 
         public Configuration setInstanceName(String instanceName) {
@@ -164,6 +171,39 @@ public class Configuration {
             this.bufferSize = bufferSize;
             return Configuration.this;
         }
+    }
+
+    public class SplitServer {
+
+        private boolean enabled = false;
+        private String localSplitStorageDirectory = System.getProperty("java.io.tmpdir") + File.separator
+                + "SplitStorage";
+        private int refreshIntervalSeconds = 86400;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getLocalSplitStorageDirectory() {
+            return localSplitStorageDirectory;
+        }
+
+        public void setLocalSplitStorageDirectory(String localSplitStorageDirectory) {
+            this.localSplitStorageDirectory = localSplitStorageDirectory;
+        }
+
+        public int getRefreshIntervalSeconds() {
+            return refreshIntervalSeconds;
+        }
+
+        public void setRefreshIntervalSeconds(int refreshIntervalSeconds) {
+            this.refreshIntervalSeconds = refreshIntervalSeconds;
+        }
+
     }
 
     public class Scan {

--- a/server/src/main/java/qonduit/operation/BatchingOperation.java
+++ b/server/src/main/java/qonduit/operation/BatchingOperation.java
@@ -9,6 +9,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import qonduit.Server;
 import qonduit.api.request.WebSocketRequest;
 import qonduit.util.JsonUtil;
 
@@ -23,9 +24,9 @@ public abstract class BatchingOperation<T> implements Operation {
     private volatile int batchSize = 100;
 
     @Override
-    public void init(ChannelHandlerContext context, AccumuloClient client, Authorizations auths, WebSocketRequest r) {
+    public void init(ChannelHandlerContext context, Server server, Authorizations auths, WebSocketRequest r) {
         this.context = context;
-        this.client = client;
+        this.client = server.getDataStore().getConnector();
         this.auths = auths;
         this.request = r;
     }

--- a/server/src/main/java/qonduit/operation/Operation.java
+++ b/server/src/main/java/qonduit/operation/Operation.java
@@ -1,9 +1,9 @@
 package qonduit.operation;
 
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 
 import io.netty.channel.ChannelHandlerContext;
+import qonduit.Server;
 import qonduit.api.request.WebSocketRequest;
 
 public interface Operation extends Runnable {
@@ -11,7 +11,7 @@ public interface Operation extends Runnable {
     /**
      * Initialize the operation so that it's ready to run
      */
-    public void init(ChannelHandlerContext context, AccumuloClient client, Authorizations auths, WebSocketRequest r);
+    public void init(ChannelHandlerContext context, Server server, Authorizations auths, WebSocketRequest r);
 
     /**
      * 

--- a/server/src/main/java/qonduit/store/SplitStore.java
+++ b/server/src/main/java/qonduit/store/SplitStore.java
@@ -1,0 +1,163 @@
+package qonduit.store;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.rfile.RFile;
+import org.apache.accumulo.core.clientImpl.Namespace;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import qonduit.Configuration;
+
+public class SplitStore {
+
+    private class RefreshTask implements Runnable {
+
+        private final AccumuloClient client;
+
+        public RefreshTask(AccumuloClient client) {
+            this.client = client;
+        }
+
+        @Override
+        public void run() {
+            for (String tableName : client.tableOperations().list()) {
+                writeSplitsForTable(client, client.tableOperations().tableIdMap(), tableName);
+            }
+        }
+
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(SplitStore.class);
+
+    private static final ConcurrentHashMap<String, AtomicReference<Path>> SPLIT_FILES = new ConcurrentHashMap<>();
+    private static final ScheduledExecutorService EXECUTOR = Executors.newScheduledThreadPool(1);
+    private static final AtomicLong FILE_COUNTER = new AtomicLong(1);
+    private static final Map<String, String> FILE_PROPS = Map.of(Property.TABLE_FILE_COMPRESSED_BLOCK_SIZE.getKey(),
+            "8K", Property.TABLE_FILE_COMPRESSED_BLOCK_SIZE_INDEX.getKey(), "100K");
+
+    public static final AtomicReference<Path> ERROR_REF = new AtomicReference<>();
+    public static final AtomicReference<Path> TABLE_DELETED_REF = new AtomicReference<>();
+
+    private final int refreshIntervalSeconds;
+    private final Path directory;
+    private final AccumuloClient client;
+    private ScheduledFuture<?> task = null;
+
+    public SplitStore(Configuration conf, AccumuloClient client) {
+        this.client = client;
+        this.directory = Path.of(conf.getAccumulo().getSplitServer().getLocalSplitStorageDirectory());
+        this.refreshIntervalSeconds = conf.getAccumulo().getSplitServer().getRefreshIntervalSeconds();
+    }
+
+    public AtomicReference<Path> getSplitsFileForTable(String tableName) {
+        return SPLIT_FILES.get(tableName);
+    }
+
+    private void deleteExistingFiles() throws IOException {
+        List<Path> existingFiles = Files.list(directory).collect(Collectors.toList());
+        for (Path p : existingFiles) {
+            LOG.info("Found existing file at startup, deleting {}", p);
+            Files.delete(p);
+        }
+    }
+
+    public void initialize() throws IOException {
+        if (Files.notExists(directory)) {
+            Files.createDirectories(directory);
+        } else if (!Files.isDirectory(directory)) {
+            throw new IOException(directory + " exists but is not a directory");
+        } else {
+            deleteExistingFiles();
+        }
+        task = EXECUTOR.scheduleWithFixedDelay(new RefreshTask(client), refreshIntervalSeconds, refreshIntervalSeconds,
+                TimeUnit.SECONDS);
+        LOG.info("SplitStore initialized");
+    }
+
+    public void writeSplitsForTable(AccumuloClient client, Map<String, String> tableMap, String tableName) {
+
+        if (tableName.startsWith(Namespace.ACCUMULO.name() + ".")) {
+            return;
+        }
+
+        LOG.debug("Getting splits for table: {}", tableName);
+        String tid = tableMap.get(tableName);
+        if (tid == null) {
+            // maybe a new table, try again
+            tableMap = client.tableOperations().tableIdMap();
+            tid = tableMap.get(tableName);
+            if (tid == null) {
+                // table deleted
+                LOG.info("{} is not in table map, maybe deleted?", tableName);
+                SPLIT_FILES.put(tableName, TABLE_DELETED_REF);
+                return;
+            }
+        }
+        final TableId tableId = TableId.of(tid);
+        try {
+            SortedSet<Text> splits = new TreeSet<>(client.tableOperations().listSplits(tableName));
+            Path tableSplitsFile = directory
+                    .resolve(tableName.replaceAll("\\.", "_") + "_splits_" + FILE_COUNTER.getAndIncrement() + ".rf");
+            LOG.debug("Writing splits for {} to {}", tableName, tableSplitsFile);
+            try (var writer = RFile.newWriter().to(tableSplitsFile.toString()).withTableProperties(FILE_PROPS)
+                    .build()) {
+                Text prev = null;
+                for (Text endRow : splits) {
+                    var extent = new KeyExtent(tableId, endRow, prev);
+                    var row = extent.toMetaRow();
+                    var key = new Key(row);
+                    key.setTimestamp(0);
+                    var encodedPrev = TabletColumnFamily.encodePrevEndRow(extent.prevEndRow());
+                    writer.append(key, encodedPrev);
+                    prev = endRow;
+                }
+                var extent = new KeyExtent(tableId, null, prev);
+                var row = extent.toMetaRow();
+                var key = new Key(row);
+                key.setTimestamp(0);
+                var encodedPrev = TabletColumnFamily.encodePrevEndRow(extent.prevEndRow());
+                writer.append(key, encodedPrev);
+            }
+            LOG.debug("Splits file {} complete for {}", tableSplitsFile, tableName);
+            SPLIT_FILES.computeIfAbsent(tableName, (t) -> new AtomicReference<Path>()).set(tableSplitsFile);
+        } catch (IOException | AccumuloSecurityException | AccumuloException e) {
+            LOG.error("Error getting / writing splits for table: " + tableName, e);
+            SPLIT_FILES.put(tableName, ERROR_REF);
+        } catch (TableNotFoundException e) {
+            // table deleted
+            SPLIT_FILES.put(tableName, TABLE_DELETED_REF);
+        }
+    }
+
+    public void close() throws IOException {
+        task.cancel(true);
+        EXECUTOR.shutdownNow();
+        deleteExistingFiles();
+    }
+
+}

--- a/server/src/main/java/qonduit/store/SplitStoreFactory.java
+++ b/server/src/main/java/qonduit/store/SplitStoreFactory.java
@@ -1,0 +1,19 @@
+package qonduit.store;
+
+import java.io.IOException;
+
+import qonduit.Configuration;
+
+public class SplitStoreFactory {
+
+    public static SplitStore create(Configuration conf, DataStore store) throws IOException {
+        if (conf.getAccumulo().getSplitServer().isEnabled()) {
+            SplitStore ss = new SplitStore(conf, store.getConnector());
+            ss.initialize();
+            return ss;
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/server/src/main/resources/spotbugs-excludes.xml
+++ b/server/src/main/resources/spotbugs-excludes.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
   <Match>
+    <Class name="~qonduit.Configuration\$.*" />
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC" />  
+  </Match>
+  <Match>
     <Class name="qonduit.Server" />
     <Method name="shutdown" />
     <Bug pattern="UC_USELESS_OBJECT" />

--- a/server/src/test/java/qonduit/ConfigurationTest.java
+++ b/server/src/test/java/qonduit/ConfigurationTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Test;
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
@@ -48,7 +47,7 @@ public class ConfigurationTest {
         assertTrue(config.getSecurity().getSsl().isUseGeneratedKeypair());
     }
 
-    @Test /* (expected = BeanCreationException.class) */
+    @Test
     public void testMissingSSLProperty() throws Exception {
         context.register(SpringBootstrap.class);
         // @formatter:off

--- a/server/src/test/java/qonduit/TestServer.java
+++ b/server/src/test/java/qonduit/TestServer.java
@@ -19,16 +19,16 @@ public class TestServer extends Server {
     }
 
     @Override
-    protected ChannelHandler setupHttpChannel(Configuration config, SslContext sslCtx) {
+    protected ChannelHandler setupHttpChannel(SslContext sslCtx) {
         return new ChannelInitializer<SocketChannel>() {
 
             @Override
             protected void initChannel(SocketChannel ch) throws Exception {
-                ch.pipeline().addLast("ssl", new NonSslRedirectHandler(config, sslCtx));
+                ch.pipeline().addLast("ssl", new NonSslRedirectHandler(getConfiguration(), sslCtx));
                 ch.pipeline().addLast("decompressor", new HttpContentDecompressor());
                 ch.pipeline().addLast("decoder", new HttpRequestDecoder());
                 ch.pipeline().addLast("aggregator", new HttpObjectAggregator(8192));
-                ch.pipeline().addLast("queryDecoder", new qonduit.netty.http.HttpRequestDecoder(config));
+                ch.pipeline().addLast("queryDecoder", new qonduit.netty.http.HttpRequestDecoder(getConfiguration()));
                 ch.pipeline().addLast("capture", httpRequests);
             }
         };

--- a/test/src/test/java/qonduit/test/integration/client/SplitClientExampleIT.java
+++ b/test/src/test/java/qonduit/test/integration/client/SplitClientExampleIT.java
@@ -1,0 +1,226 @@
+package qonduit.test.integration.client;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+
+import javax.net.ssl.SSLContext;
+import javax.websocket.CloseReason;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.Session;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.NamespaceExistsException;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.hadoop.io.Text;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import qonduit.Server;
+import qonduit.auth.AuthCache;
+import qonduit.client.websocket.ClientHandler;
+import qonduit.client.websocket.WebSocketClient;
+import qonduit.operations.splits.SplitLookupRequest;
+import qonduit.operations.splits.SplitLookupResponse;
+import qonduit.serialize.JsonSerializer;
+import qonduit.test.IntegrationTest;
+import qonduit.test.integration.OneWaySSLBase;
+
+@Category(IntegrationTest.class)
+public class SplitClientExampleIT extends OneWaySSLBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SplitClientExampleIT.class);
+
+    private SSLContext sslCtx = null;
+    private Server s = null;
+
+    private void setupSslCtx() throws Exception {
+        Assert.assertNotNull(clientTrustStoreFile);
+        SslContextBuilder builder = SslContextBuilder.forClient();
+        builder.applicationProtocolConfig(ApplicationProtocolConfig.DISABLED);
+        builder.sslProvider(SslProvider.JDK);
+        builder.trustManager(clientTrustStoreFile); // Trust the server cert
+        SslContext ctx = builder.build();
+        Assert.assertTrue(ctx.isClient());
+        JdkSslContext jdk = (JdkSslContext) ctx;
+        sslCtx = jdk.context();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        conf.getAccumulo().getSplitServer().setEnabled(true);
+        conf.getAccumulo().getSplitServer().setRefreshIntervalSeconds(5);
+        s = new Server(conf);
+        s.run();
+        setupSslCtx();
+        clearTablesResetConf();
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        s.shutdown();
+        clearTablesResetConf();
+        AuthCache.resetSessionMaxAge();
+    }
+
+    private Text charsToText(int... values) {
+        StringBuffer buf = new StringBuffer();
+        for (int i : values) {
+            buf.append(Character.toString(i));
+        }
+        return new Text(buf.toString());
+    }
+
+    @Test
+    public void testSplitLookup() throws Exception {
+
+        final String tableName = "qonduit.splitClientTest";
+        final SortedSet<Text> expectedSplits = new TreeSet<>();
+        // create a-z, aa-zz, aaa-zzz, aaaa-zzzz splits
+        IntStream.rangeClosed(97, 122).forEach(i -> expectedSplits.add(charsToText(i)));
+        IntStream.rangeClosed(97, 122).forEach(i -> expectedSplits.add(charsToText(i, i)));
+        IntStream.rangeClosed(97, 122).forEach(i -> expectedSplits.add(charsToText(i, i, i)));
+        IntStream.rangeClosed(97, 122).forEach(i -> expectedSplits.add(charsToText(i, i, i, i)));
+
+        final NewTableConfiguration ntc = new NewTableConfiguration();
+        ntc.withSplits(expectedSplits);
+        try (AccumuloClient accumulo = mac.createAccumuloClient(MAC_ROOT_USER, new PasswordToken(MAC_ROOT_PASSWORD))) {
+            try {
+                accumulo.namespaceOperations().create("qonduit");
+            } catch (NamespaceExistsException e) {
+            }
+            accumulo.tableOperations().create(tableName, ntc);
+            Collection<Text> actualSplits = accumulo.tableOperations().listSplits(tableName);
+            Assert.assertEquals(expectedSplits, new TreeSet<Text>(actualSplits));
+        }
+
+        // Table with splits created, Qonduit server is up with Split operation enabled
+        // and a 5 second refresh.
+
+        // A websocket is an asynchronous bi-directional transport. Create a connection
+        // to the Qonduit server.
+        WebSocketClient client = new WebSocketClient(sslCtx, "localhost", 54322, 54323, false, null, null, false,
+                1048576);
+
+        // Create a ClientHandler that will be used by the WebSocketClient to handle
+        // responses
+        // coming from the Qonduit server.
+        final ConcurrentHashMap<String, SplitLookupRequest> requests = new ConcurrentHashMap<>();
+        final ConcurrentHashMap<String, SplitLookupResponse> responses = new ConcurrentHashMap<>();
+        final AtomicBoolean responseFailureOccurred = new AtomicBoolean(false);
+        final AtomicBoolean websocketFailureOccurred = new AtomicBoolean(false);
+        ClientHandler handler = new ClientHandler() {
+
+            @Override
+            public void onOpen(Session session, EndpointConfig config) {
+                LOG.info("Websocket session {} opened.", session.getId());
+                session.addMessageHandler(new MessageHandler.Whole<byte[]>() {
+
+                    @Override
+                    public void onMessage(byte[] message) {
+                        try {
+                            SplitLookupResponse response = JsonSerializer.getObjectMapper().readValue(message,
+                                    SplitLookupResponse.class);
+                            var oldVal = responses.putIfAbsent(response.getRequestId(), response);
+                            if (oldVal != null) {
+                                LOG.error("Received duplicate response for row {}",
+                                        requests.get(response.getRequestId()));
+                                responseFailureOccurred.set(true);
+                            }
+                        } catch (IOException e) {
+                            LOG.error("Error deserializing response", e);
+                            responseFailureOccurred.set(true);
+                        }
+                        LOG.info("Message received on Websocket session {}: {}", session.getId(), message);
+                    }
+                });
+            }
+
+            @Override
+            public void onClose(Session session, CloseReason reason) {
+                LOG.info("Websocket session {} closed.", session.getId());
+            }
+
+            @Override
+            public void onError(Session session, Throwable error) {
+                LOG.error("Error occurred on Websocket session" + session.getId(), error);
+                websocketFailureOccurred.set(true);
+            }
+
+        };
+
+        List<Text> randomSplits = new ArrayList<>(expectedSplits);
+        Collections.shuffle(randomSplits);
+        Assert.assertEquals(expectedSplits.size(), randomSplits.size());
+
+        // Build the requests
+        for (Text randomSplit : randomSplits) {
+            String requestId = UUID.randomUUID().toString();
+            SplitLookupRequest request = new SplitLookupRequest();
+            request.setRequestId(requestId);
+            request.setTableName(tableName);
+            request.setRow(randomSplit.toString());
+            requests.put(requestId, request);
+        }
+        Assert.assertEquals(randomSplits.size(), requests.size());
+
+        // Let's give the server time to create the splits file
+        Thread.sleep(10_000);
+
+        client.open(handler); // this is synchronous
+        for (SplitLookupRequest r : requests.values()) {
+            client.sendRequest(r);
+        }
+        LOG.info("Sent all requests");
+
+        while (!websocketFailureOccurred.get() && !responseFailureOccurred.get()
+                && responses.size() != requests.size()) {
+            Thread.sleep(1000);
+        }
+        Assert.assertFalse(websocketFailureOccurred.get());
+        Assert.assertFalse(responseFailureOccurred.get());
+
+        // Close the websocket connection
+        client.close();
+
+        // Process the results
+        Iterator<Entry<String, SplitLookupResponse>> iter = responses.entrySet().iterator();
+        while (iter.hasNext()) {
+            Entry<String, SplitLookupResponse> e = iter.next();
+            iter.remove();
+            String requestId = e.getKey();
+            SplitLookupResponse res = e.getValue();
+            Assert.assertFalse(res.getErrorMessage(), res.isError());
+            SplitLookupRequest req = requests.remove(requestId);
+            Assert.assertNotNull(req);
+            LOG.info("Split for row {} is {}->{}", req.getRow(), res.getBeginRow(), res.getEndRow());
+        }
+        Assert.assertEquals(0, requests.size());
+        Assert.assertEquals(0, responses.size());
+
+    }
+
+}

--- a/test/src/test/java/qonduit/test/integration/client/SplitStoreIT.java
+++ b/test/src/test/java/qonduit/test/integration/client/SplitStoreIT.java
@@ -1,0 +1,132 @@
+package qonduit.test.integration.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.util.Pair;
+import org.apache.hadoop.io.Text;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import qonduit.Server;
+import qonduit.auth.AuthCache;
+import qonduit.client.websocket.WebSocketClient;
+import qonduit.operations.splits.SplitLookupRequest;
+import qonduit.operations.splits.SplitLookupResponse;
+import qonduit.serialize.JsonSerializer;
+import qonduit.test.IntegrationTest;
+import qonduit.test.integration.OneWaySSLBase;
+
+@Category(IntegrationTest.class)
+public class SplitStoreIT extends OneWaySSLBase {
+
+    private SSLContext sslCtx = null;
+    private Server s = null;
+
+    private void setupSslCtx() throws Exception {
+        Assert.assertNotNull(clientTrustStoreFile);
+        SslContextBuilder builder = SslContextBuilder.forClient();
+        builder.applicationProtocolConfig(ApplicationProtocolConfig.DISABLED);
+        builder.sslProvider(SslProvider.JDK);
+        builder.trustManager(clientTrustStoreFile); // Trust the server cert
+        SslContext ctx = builder.build();
+        Assert.assertTrue(ctx.isClient());
+        JdkSslContext jdk = (JdkSslContext) ctx;
+        sslCtx = jdk.context();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        conf.getAccumulo().getSplitServer().setEnabled(true);
+        conf.getAccumulo().getSplitServer().setRefreshIntervalSeconds(5);
+        s = new Server(conf);
+        s.run();
+        setupSslCtx();
+        clearTablesResetConf();
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        s.shutdown();
+        clearTablesResetConf();
+        AuthCache.resetSessionMaxAge();
+    }
+
+    private Pair<String, String> doSplitLookup(WebSocketClient client, String tableName, String row,
+            boolean errorExpected, String errMsgPrefix) throws Exception {
+        List<byte[]> responses = new ArrayList<>();
+        String id = UUID.randomUUID().toString();
+        SplitLookupRequest request = new SplitLookupRequest();
+        request.setRequestId(id);
+        request.setTableName(tableName);
+        request.setRow(row);
+        WebSocketClientIT.doIt(client, request, responses, 1);
+        Assert.assertEquals(1, responses.size());
+        SplitLookupResponse response = JsonSerializer.getObjectMapper().readValue(responses.get(0),
+                SplitLookupResponse.class);
+        Assert.assertEquals(id, response.getRequestId());
+        Assert.assertEquals(response.getErrorMessage(), response.isError(), errorExpected);
+        Assert.assertTrue(response.isEndOfResults());
+        if (errorExpected) {
+            Assert.assertTrue(response.getErrorMessage().startsWith(errMsgPrefix));
+            return null;
+        } else {
+            return new Pair<>(response.getBeginRow(), response.getEndRow());
+        }
+    }
+
+    @Test
+    public void testSplitStore() throws Exception {
+        WebSocketClient client = new WebSocketClient(sslCtx, "localhost", 54322, 54323, false, null, null, false,
+                65536);
+        Assert.assertNull(
+                doSplitLookup(client, RootTable.NAME, "a", true, "SplitStore does not keep splits for table: "));
+        Assert.assertNull(
+                doSplitLookup(client, MetadataTable.NAME, "a", true, "SplitStore does not keep splits for table: "));
+        Assert.assertNull(doSplitLookup(client, "fakeTable", "a", true, "Table does not exist: "));
+
+        String tableName = "qonduit.splitTest";
+
+        SortedSet<Text> splits = new TreeSet<>();
+        // a-z
+        IntStream.rangeClosed(97, 122).forEach(i -> splits.add(new Text(i + "")));
+
+        NewTableConfiguration ntc = new NewTableConfiguration();
+        ntc.withSplits(splits);
+
+        AccumuloClient accumulo = mac.createAccumuloClient(MAC_ROOT_USER, new PasswordToken(MAC_ROOT_PASSWORD));
+        accumulo.namespaceOperations().create("qonduit");
+        accumulo.tableOperations().create(tableName);
+
+        Assert.assertNull(doSplitLookup(client, tableName, "a", true, "Splits file not created yet for table: "));
+
+        Thread.sleep(10000);
+
+        Pair<String, String> results = doSplitLookup(client, tableName, "_a", false, null);
+        Assert.assertNotNull(results);
+        Assert.assertEquals("null", results.getFirst());
+        Assert.assertEquals("a", results.getSecond());
+
+    }
+
+}

--- a/test/src/test/resources/log4j2.xml
+++ b/test/src/test/resources/log4j2.xml
@@ -6,12 +6,14 @@
     </Console>
   </Appenders>
   <Loggers>
+    <Logger name="org.apache.accumulo.core" level="WARN" additivity="false" />
     <Logger name="org.apache.accumulo.core.client.impl.ThriftTransportPool" level="OFF" additivity="false" />
     <Logger name="org.apache.accumulo.fate.zookeeper.ZooCache" level="OFF" additivity="false" />
+    <Logger name="org.apache.hadoop.io.compress.CodecPool" level="OFF" additivity="false" />
     <Logger name="org.apache.zookeeper" level="OFF" additivity="false" />
     <Logger name="javax.net.debug" level="ALL" additivity="false"/>
     <Logger name="sun.net.www.protocol.http.HttpURLConnection" level="ALL" additivity="false" />
-    <Root level="TRACE">
+    <Root level="DEBUG">
       <AppenderRef ref="CONSOLE"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
Modified Qonduit server to optionally serve up split
information for user tables. When enabled the SplitStore
component in the Qonduit server will periodically get
the splits for user tables and store them in RFiles on
local disk (location can be configured).

Users can use the `WebSocketClient` object
to connect to the Qonduit server and send
`SplitLookupRequest` objects over the connection.
On the server side, the request is routed to the
`SplitLookupOperation` class where the row is
searched in the split file for the table. The operation
returns a `SplitLookupResponse` object back to
the user.

Included several IT changes, including an IT that
shows how to wire everything together.